### PR TITLE
Remove unused MalformedURLException

### DIFF
--- a/app/src/main/java/edu/byu/cs/tweeter/client/view/main/MainActivity.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/view/main/MainActivity.java
@@ -22,7 +22,6 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.tabs.TabLayout;
 import com.squareup.picasso.Picasso;
 
-import java.net.MalformedURLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
@@ -199,7 +198,7 @@ public class MainActivity extends AppCompatActivity implements StatusDialogFragm
         return statusFormat.format(userFormat.parse(LocalDate.now().toString() + " " + LocalTime.now().toString().substring(0, 8)));
     }
 
-    public List<String> parseURLs(String post) throws MalformedURLException {
+    public List<String> parseURLs(String post) {
         List<String> containedUrls = new ArrayList<>();
         for (String word : post.split("\\s")) {
             if (word.startsWith("http://") || word.startsWith("https://")) {

--- a/app/src/main/java/edu/byu/cs/tweeter/client/view/main/feed/FeedFragment.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/view/main/feed/FeedFragment.java
@@ -28,7 +28,6 @@ import com.squareup.picasso.Picasso;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -88,11 +87,7 @@ public class FeedFragment extends Fragment {
         LinearLayoutManager layoutManager = new LinearLayoutManager(this.getContext());
         feedRecyclerView.setLayoutManager(layoutManager);
 
-        try {
-            feedRecyclerViewAdapter = new FeedRecyclerViewAdapter();
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        }
+        feedRecyclerViewAdapter = new FeedRecyclerViewAdapter();
         feedRecyclerView.setAdapter(feedRecyclerViewAdapter);
 
         feedRecyclerView.addOnScrollListener(new FeedRecyclerViewPaginationScrollListener(layoutManager));
@@ -233,7 +228,7 @@ public class FeedFragment extends Fragment {
         /**
          * Creates an instance and loads the first page of feed data.
          */
-        FeedRecyclerViewAdapter() throws MalformedURLException {
+        FeedRecyclerViewAdapter() {
             loadMoreItems();
         }
 
@@ -337,7 +332,7 @@ public class FeedFragment extends Fragment {
          * Causes the Adapter to display a loading footer and make a request to get more feed
          * data.
          */
-        void loadMoreItems() throws MalformedURLException {
+        void loadMoreItems(){
             if (!isLoading) {   // This guard is important for avoiding a race condition in the scrolling code.
                 isLoading = true;
                 addLoadingFooter();
@@ -353,7 +348,7 @@ public class FeedFragment extends Fragment {
          * Adds a dummy status to the list of statuses so the RecyclerView will display a view (the
          * loading footer view) at the bottom of the list.
          */
-        private void addLoadingFooter() throws MalformedURLException {
+        private void addLoadingFooter() {
             addItem(new Status("Dummy Post", new User("firstName", "lastName", "@coolAlias"), "2020-10-31 00:00:00", new ArrayList<String>() {{
                 add("https://youtube.com");
             }}, new ArrayList<String>() {{
@@ -438,11 +433,7 @@ public class FeedFragment extends Fragment {
                     // Run this code later on the UI thread
                     final Handler handler = new Handler(Looper.getMainLooper());
                     handler.postDelayed(() -> {
-                        try {
                             feedRecyclerViewAdapter.loadMoreItems();
-                        } catch (MalformedURLException e) {
-                            e.printStackTrace();
-                        }
                     }, 0);
                 }
             }

--- a/app/src/main/java/edu/byu/cs/tweeter/client/view/main/story/StoryFragment.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/view/main/story/StoryFragment.java
@@ -28,7 +28,6 @@ import com.squareup.picasso.Picasso;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -88,11 +87,7 @@ public class StoryFragment extends Fragment {
         LinearLayoutManager layoutManager = new LinearLayoutManager(this.getContext());
         storyRecyclerView.setLayoutManager(layoutManager);
 
-        try {
-            storyRecyclerViewAdapter = new StoryRecyclerViewAdapter();
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        }
+        storyRecyclerViewAdapter = new StoryRecyclerViewAdapter();
         storyRecyclerView.setAdapter(storyRecyclerViewAdapter);
 
         storyRecyclerView.addOnScrollListener(new StoryRecyclerViewPaginationScrollListener(layoutManager));
@@ -236,7 +231,7 @@ public class StoryFragment extends Fragment {
         /**
          * Creates an instance and loads the first page of story data.
          */
-        StoryRecyclerViewAdapter() throws MalformedURLException {
+        StoryRecyclerViewAdapter() {
             loadMoreItems();
         }
 
@@ -340,7 +335,7 @@ public class StoryFragment extends Fragment {
          * Causes the Adapter to display a loading footer and make a request to get more story
          * data.
          */
-        void loadMoreItems() throws MalformedURLException {
+        void loadMoreItems() {
             if (!isLoading) {   // This guard is important for avoiding a race condition in the scrolling code.
                 isLoading = true;
                 addLoadingFooter();
@@ -441,11 +436,7 @@ public class StoryFragment extends Fragment {
                     // Run this code later on the UI thread
                     final Handler handler = new Handler(Looper.getMainLooper());
                     handler.postDelayed(() -> {
-                        try {
                             storyRecyclerViewAdapter.loadMoreItems();
-                        } catch (MalformedURLException e) {
-                            e.printStackTrace();
-                        }
                     }, 0);
                 }
             }


### PR DESCRIPTION
I assume this is legacy code - I can't remember any reason we had this except that maybe at one point the code to parse URLs was significantly more complex.

I've removing it because of the unfortunate reach it has - making complex handler.postDelayed calls and anytime these two presenters are newed up, they need to be wrapped in a try/catch.