### PR TITLE
Update shadow to use new Plugins DSL, work with gradle 7.1 and tools

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,9 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    compileSdk 30
     defaultConfig {
         applicationId "edu.byu.cs.tweeter"
         minSdkVersion 30

--- a/build.gradle
+++ b/build.gradle
@@ -1,30 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    repositories {
-        mavenCentral()
-        google()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
-        
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        mavenCentral()
-        google()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
+plugins {
+    id 'com.android.application' version '7.1.0' apply false
+    id 'com.android.library' version '7.1.0' apply false
+    id "com.github.johnrengelman.shadow" version "7.1.2"
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,18 @@
-include ':app'
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 rootProject.name='Tweeter'
+include ':app'
 include ':shared'


### PR DESCRIPTION
Clicking on the upgrade button seems to be a popular action. The current build.gradle setup does not work automatically, and these changes remedy that.

1. Remove `buildscript` because 
     - shadowJar can be replaced with a single line in the plugins DSL
     - gradle tools doesn't seem to be needed anymore? newly created projects don't use this
2. Remove `allprojects` in favor of `settings.gradle` changes to include `pluginManagement` and `dependencyResolutionManagement`
3. Update `plugins` to use the DSL in the app, and update to newest version
4. Remove `maven` custom url because it was only used for the shadowJar


I'm pretty nervous about this one. I've tested on this repository and on the `tweeter-samples-java` repository and both work. 

- Do dynamodb dependencies still work? 
- Also, what about the removed dependency on the com.android.tools.build.gradle? How do new projects know which version of gradle? 
- What is the difference between the com.android.application (still there) vs com.android.library (new) plugin?
- Does this work on Android Studio less than BumbleBee (e.g. Arctic Fox)
- Does this work when older versions of gradle are installed, and install the correct new version?