### PR TITLE
Remove dead code in Mention parsing

### DIFF
--- a/app/src/main/java/edu/byu/cs/tweeter/client/view/main/feed/FeedFragment.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/view/main/feed/FeedFragment.java
@@ -158,16 +158,11 @@ public class FeedFragment extends Fragment {
 
                         String clickable = s.subSequence(start, end).toString();
 
-                        if (clickable.contains("http")) {
-                            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(clickable));
-                            startActivity(intent);
-                        } else {
-                            GetUserTask getUserTask = new GetUserTask(Cache.getInstance().getCurrUserAuthToken(),
-                                    clickable, new GetUserHandler());
-                            ExecutorService executor = Executors.newSingleThreadExecutor();
-                            executor.execute(getUserTask);
-                            Toast.makeText(getContext(), "Getting user's profile...", Toast.LENGTH_LONG).show();
-                        }
+                        GetUserTask getUserTask = new GetUserTask(Cache.getInstance().getCurrUserAuthToken(),
+                                clickable, new GetUserHandler());
+                        ExecutorService executor = Executors.newSingleThreadExecutor();
+                        executor.execute(getUserTask);
+                        Toast.makeText(getContext(), "Getting user's profile...", Toast.LENGTH_LONG).show();
                     }
 
                     @Override

--- a/app/src/main/java/edu/byu/cs/tweeter/client/view/main/feed/FeedFragment.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/view/main/feed/FeedFragment.java
@@ -19,6 +19,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -167,7 +168,7 @@ public class FeedFragment extends Fragment {
                     @Override
                     public void updateDrawState(@NotNull TextPaint ds) {
                         super.updateDrawState(ds);
-                        ds.setColor(getResources().getColor(R.color.colorAccent));
+                        ds.setColor(ContextCompat.getColor(getContext(), R.color.colorAccent));
                         ds.setUnderlineText(false);
                     }
                 }, startIndex, (startIndex + mention.length()), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);

--- a/app/src/main/java/edu/byu/cs/tweeter/client/view/main/feed/FeedFragment.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/view/main/feed/FeedFragment.java
@@ -1,7 +1,6 @@
 package edu.byu.cs.tweeter.client.view.main.feed;
 
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;

--- a/app/src/main/java/edu/byu/cs/tweeter/client/view/main/story/StoryFragment.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/view/main/story/StoryFragment.java
@@ -1,7 +1,6 @@
 package edu.byu.cs.tweeter.client.view.main.story;
 
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;

--- a/app/src/main/java/edu/byu/cs/tweeter/client/view/main/story/StoryFragment.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/view/main/story/StoryFragment.java
@@ -19,6 +19,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -167,7 +168,7 @@ public class StoryFragment extends Fragment {
                     @Override
                     public void updateDrawState(@NotNull TextPaint ds) {
                         super.updateDrawState(ds);
-                        ds.setColor(getResources().getColor(R.color.colorAccent));
+                        ds.setColor(ContextCompat.getColor(getContext(), R.color.colorAccent));
                         ds.setUnderlineText(false);
                     }
                 };

--- a/app/src/main/java/edu/byu/cs/tweeter/client/view/main/story/StoryFragment.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/view/main/story/StoryFragment.java
@@ -158,17 +158,11 @@ public class StoryFragment extends Fragment {
 
                         String clickable = s.subSequence(start, end).toString();
 
-
-                        if (clickable.contains("http")) {
-                            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(clickable));
-                            startActivity(intent);
-                        } else {
-                            GetUserTask getUserTask = new GetUserTask(Cache.getInstance().getCurrUserAuthToken(),
-                                    clickable, new GetUserHandler());
-                            ExecutorService executor = Executors.newSingleThreadExecutor();
-                            executor.execute(getUserTask);
-                            Toast.makeText(getContext(), "Getting user's profile...", Toast.LENGTH_LONG).show();
-                        }
+                        GetUserTask getUserTask = new GetUserTask(Cache.getInstance().getCurrUserAuthToken(),
+                                clickable, new GetUserHandler());
+                        ExecutorService executor = Executors.newSingleThreadExecutor();
+                        executor.execute(getUserTask);
+                        Toast.makeText(getContext(), "Getting user's profile...", Toast.LENGTH_LONG).show();
                     }
 
                     @Override


### PR DESCRIPTION
Remove dead code in the mentions parsing code, which incorrectly accounted for HTTP links inside of mentions (rather than in the URLs).

Update deprecated `getColor()` method in same rendering code.