### PR TITLE
Fix: Tweeter app crashes if no username provided and user clicks log in

### DIFF
--- a/app/src/main/java/edu/byu/cs/tweeter/client/view/login/LoginFragment.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/view/login/LoginFragment.java
@@ -84,7 +84,7 @@ public class LoginFragment extends Fragment {
     }
 
     public void validateLogin() {
-        if (alias.getText().charAt(0) != '@') {
+        if (alias.getText().length() > 0 && alias.getText().charAt(0) != '@') {
             throw new IllegalArgumentException("Alias must begin with @.");
         }
         if (alias.getText().length() < 2) {


### PR DESCRIPTION
Tweeter app crashes if no username provided and user clicks log in -> alias is empty string, tries to call alias.charAt(0) first thing, gets index out of bounds.

Add a check to first if statement to make sure that the string is longer than length 0