### PR TITLE
Status not serializable error fixed.

### DIFF
--- a/app/src/main/java/edu/byu/cs/tweeter/client/view/main/feed/FeedFragment.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/view/main/feed/FeedFragment.java
@@ -40,6 +40,7 @@ import edu.byu.cs.tweeter.client.cache.Cache;
 import edu.byu.cs.tweeter.client.view.main.MainActivity;
 import edu.byu.cs.tweeter.model.domain.Status;
 import edu.byu.cs.tweeter.model.domain.User;
+import edu.byu.cs.tweeter.util.Timestamp;
 
 /**
  * Implements the "Feed" tab.
@@ -141,7 +142,7 @@ public class FeedFragment extends Fragment {
             Picasso.get().load(status.getUser().getImageUrl()).into(userImage);
             userAlias.setText(status.getUser().getAlias());
             userName.setText(status.getUser().getName());
-            datetime.setText(status.getFormattedDate());
+            datetime.setText(Timestamp.getFormattedDate(status.getTimestamp()));
 
             // @mentions and urls clickable
             SpannableString spannableString = new SpannableString(status.getPost());

--- a/app/src/main/java/edu/byu/cs/tweeter/client/view/main/story/StoryFragment.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/view/main/story/StoryFragment.java
@@ -40,6 +40,7 @@ import edu.byu.cs.tweeter.client.cache.Cache;
 import edu.byu.cs.tweeter.client.view.main.MainActivity;
 import edu.byu.cs.tweeter.model.domain.Status;
 import edu.byu.cs.tweeter.model.domain.User;
+import edu.byu.cs.tweeter.util.Timestamp;
 
 /**
  * Implements the "Story" tab.
@@ -141,7 +142,7 @@ public class StoryFragment extends Fragment {
             Picasso.get().load(status.getUser().getImageUrl()).into(userImage);
             userAlias.setText(status.getUser().getAlias());
             userName.setText(status.getUser().getName());
-            datetime.setText(status.getFormattedDate());
+            datetime.setText(Timestamp.getFormattedDate(status.getTimestamp()));
 
             // @mentions and urls clickable
             SpannableString spannableString = new SpannableString(status.getPost());

--- a/shared/src/main/java/edu/byu/cs/tweeter/model/domain/Status.java
+++ b/shared/src/main/java/edu/byu/cs/tweeter/model/domain/Status.java
@@ -55,9 +55,6 @@ public class Status implements Serializable {
         return timestamp;
     }
 
-    public String getFormattedDate() {
-        return new SimpleDateFormat("E MMM d k:mm:ss z y", Locale.US).format(new Date(timestamp));
-    }
     public String getPost() {
         return post;
     }

--- a/shared/src/main/java/edu/byu/cs/tweeter/util/Timestamp.java
+++ b/shared/src/main/java/edu/byu/cs/tweeter/util/Timestamp.java
@@ -1,0 +1,11 @@
+package edu.byu.cs.tweeter.util;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class Timestamp {
+    public static String getFormattedDate(long timestamp) {
+        return new SimpleDateFormat("E MMM d k:mm:ss z y", Locale.US).format(new Date(timestamp));
+    }
+}


### PR DESCRIPTION
Status not serializable error fixed by moving 'getFormattedDate()' function out of Status and into a new Timestamp class.